### PR TITLE
fix: Use project name for Maven artifact ID

### DIFF
--- a/src/main/kotlin/app/morphe/patches/gradle/PatchesPlugin.kt
+++ b/src/main/kotlin/app/morphe/patches/gradle/PatchesPlugin.kt
@@ -148,6 +148,7 @@ abstract class PatchesPlugin : Plugin<Project> {
             extension.publications { container ->
                 container.create("MorphePatches", MavenPublication::class.java) {
                     it.from(components["java"])
+                    it.artifactId = rootProject.name
 
                     val about = patchesExtension.about
                     it.pom { pom ->


### PR DESCRIPTION
Fixes #5 by using the root project name for the Maven artifact ID.

This causes the Maven publish task to GitHub to look like this instead of `app.morphe.patches`: https://github.com/wchill/rvx-morphed/packages/2804228