### PR TITLE
fix: Set the min API level for D8 to prevent unnecessary desugaring

### DIFF
--- a/src/main/kotlin/app/morphe/patches/gradle/PatchesPlugin.kt
+++ b/src/main/kotlin/app/morphe/patches/gradle/PatchesPlugin.kt
@@ -126,10 +126,12 @@ abstract class PatchesPlugin : Plugin<Project> {
                     .addProgramResourceProvider(ArchiveResourceProvider.fromArchive(patchesFile.toPath(), true))
                     .setMode(CompilationMode.RELEASE)
                     .setOutput(classesZipFile.toPath(), OutputMode.DexIndexed)
+                    .setMinApiLevel(26)
 
-                // Add android.jar as a library to D8 to allow desugaring.
-                val androidJar = getAndroidJar() ?: throw GradleException("Could not find android.jar")
-                d8Builder.addLibraryFiles(androidJar.toPath())
+                // Add android.jar as a library to D8 to allow desugaring if it is found.
+                getAndroidJar()?.let {
+                    d8Builder.addLibraryFiles(it.toPath())
+                }
 
                 // Add the compile and runtime classpath to D8 to allow desugaring project dependencies.
                 val runtimeClasspath = configurations.getByName("runtimeClasspath")


### PR DESCRIPTION
Set a minSdk value for D8 command in the buildAndroid task.
This prevents unnecessary desugaring from being performed.
Since Morphe Manager is minSdk 26, the patches' classes.dex also can be 26.

Apparently, desugaring does not actually take place when min API level is 24+.
Even if I don't provide the library file and classpath, no warnings are displayed during desugaring.
Therefore, I made the android.jar not mandatory.

Optionally, I can also completely remove the code that retrieves android.jar and the classpath if you would like.

Note that this min API level does not affect the patched APK.
Patched apps continue to work according to their respective minSdkVersion.